### PR TITLE
Example of moving the headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.o
+*.gch
+*.a
+check_mandelbrot
+main

--- a/graph.c
+++ b/graph.c
@@ -10,8 +10,8 @@ graph_create(const char *backend, const size_t width, const size_t height,
         const complex double center, const double range)
 {
     graph_t graph = {
-        0,
-        NULL,
+        CAIRO,
+        {NULL},
         width,
         height,
         center,
@@ -28,17 +28,17 @@ graph_create(const char *backend, const size_t width, const size_t height,
     if (0 == strcmp("cairo", backend)) {
         graph.image_type = CAIRO;
 
-        graph.image = cairo_create(
+        graph.cairo_image = cairo_create(
                 cairo_image_surface_create(CAIRO_FORMAT_RGB24, width, height));
 
-        cairo_set_line_width(graph.image, 0.1);
+        cairo_set_line_width(graph.cairo_image, 0.1);
     } else {
         graph.image_type = GD;
 
-        graph.image = gdImageCreate(width, height);
+        graph.gd_image = gdImageCreate(width, height);
 
         for (size_t i = 0; i < NUM_COLORS; i++) {
-            gdImageColorAllocate(graph.image,
+            gdImageColorAllocate(graph.gd_image,
                     graph.colormap[i][0],
                     graph.colormap[i][1],
                     graph.colormap[i][2]);
@@ -110,15 +110,15 @@ graph_set_pixel(const graph_t graph,
 {
     switch (graph.image_type) {
         case CAIRO:
-            cairo_rectangle(graph.image, horizontal, vertical, 1, 1);
-            cairo_set_source_rgb(graph.image,
+            cairo_rectangle(graph.cairo_image, horizontal, vertical, 1, 1);
+            cairo_set_source_rgb(graph.cairo_image,
                     graph.colormap[colormap_entry][0] / 255.0,
                     graph.colormap[colormap_entry][1] / 255.0,
                     graph.colormap[colormap_entry][2] / 255.0);
-            cairo_fill(graph.image);
+            cairo_fill(graph.cairo_image);
             break;
         case GD:
-            gdImageSetPixel(graph.image, horizontal, vertical,
+            gdImageSetPixel(graph.gd_image, horizontal, vertical,
                     colormap_entry);
             break;
         default:
@@ -133,12 +133,12 @@ graph_write(const graph_t graph, const char *outputfile)
 
     switch (graph.image_type) {
         case CAIRO:
-            cairo_surface_write_to_png(cairo_get_target(graph.image),
+            cairo_surface_write_to_png(cairo_get_target(graph.cairo_image),
                     outputfile);
             break;
         case GD:
             pngout = fopen(outputfile, "wb");
-            gdImagePng(graph.image, pngout);
+            gdImagePng(graph.gd_image, pngout);
             fclose(pngout);
             break;
         default:
@@ -151,13 +151,12 @@ graph_destroy(const graph_t graph)
 {
     switch (graph.image_type) {
         case CAIRO:
-            cairo_destroy(graph.image);
+            cairo_destroy(graph.cairo_image);
             break;
         case GD:
-            gdImageDestroy(graph.image);
+            gdImageDestroy(graph.gd_image);
             break;
         default:
             break;
     }
 }
-

--- a/graph.h
+++ b/graph.h
@@ -1,4 +1,9 @@
+#ifndef GRAPH_H
+#define GRAPH_H
+
 #include <complex.h>
+#include <cairo/cairo.h>
+#include <gd.h>
 
 typedef struct extreme_coordinates {
     complex double lower_left;
@@ -9,7 +14,10 @@ typedef struct extreme_coordinates {
 enum ImageType { CAIRO, GD };
 typedef struct graph {
     enum ImageType image_type;
-    void *image;
+    union {
+          gdImagePtr gd_image;	    /* gdImagePtr */
+          cairo_t *cairo_image;	/* cairo_t *  */
+       };
     const size_t width;
     const size_t height;
     const complex double center;
@@ -24,3 +32,5 @@ void graph_destroy(const graph_t);
 complex double graph_get_coordinates(graph_t, const size_t, const size_t);
 void graph_set_pixel(const graph_t, const size_t, const size_t, const size_t);
 void graph_write(const graph_t, const char *);
+
+#endif


### PR DESCRIPTION
 to allow use of the gd and cairo library types in graph.h

This does not use forward declares, it just puts the required header inlcudes in graph.h
This gets the types declared where needed and ensures the user of the graph.h/.c does not have to 
remember to add the includes to their source file.

I experimented with forward declaring the two types. It worked fine for the cairo_t since it is just a struct. It did not work for gdImagePtr because it is a typedef already. I think there is some way to do it, but I got tired.

I think putting the includes in is an acceptable approach. Those headers must be incldued by someone and including the where the are needed removed the burden of knowing to do it from the library user.

Just using the void\* the way you have is also acceptable (and is be a common C idiom). I think it is clearer with the union and the explicit names (although, in general, I give side-eyes to unions. This type of use is one of the few examples where they other solutions like casting a void\* to one of several types).

(This PR is really just for the conversation.)
